### PR TITLE
Switch from js-yaml to yamljs

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ function Validator(schema) {
  * Validate against a string.
  *
  * @param {string} yamlContents - String of YML to validate
- * @returns {array} errors - Validation errors, if any. Otherwise returns nothing
+ * @returns {array} errors - Validation errors, if any. Otherwise returns
+ *   nothing
  */
 Validator.prototype.validate = function (yamlContents) {
   var jsonContents,

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var jsonSchema = require('json-schema');
-var jsYaml = require('js-yaml');
+var yamlJs = require('yamljs');
 var referenceSchema = require('./lib/draft-04-schema.json');
 var aboutSchema = require('./lib/schema.json');
 var packageInfo = require('./package.json');
@@ -44,7 +44,7 @@ Validator.prototype.validate = function (yamlContents) {
       result;
 
   try {
-    jsonContents = jsYaml.safeLoad(yamlContents);
+    jsonContents = yamlJs.parse(yamlContents);
   } catch (err) {
     return [err.toString()];
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "github": "^0.2.4",
-    "js-yaml": "^3.4.6",
-    "json-schema": "^0.2.2"
+    "json-schema": "^0.2.2",
+    "yamljs": "^0.2.4"
   }
 }

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -42,11 +42,11 @@ describe('validate', function() {
 
   it('should return an array of errors if the YAML fails to parse',
     function() {
-      var yamlContents = 'lyric: watch out boy: she\'ll chew you up!',
+      var yamlContents = 'lyric: "watch out boy: she\'ll chew you up!',
           results = validator.validate(yamlContents);
 
       expect(results).to.not.be.empty;
-      expect(results[0]).to.have.string('YAMLException');
+      expect(results[0]).to.have.string('ParseException');
   });
 
   it('should return nothing if the YAML content is valid', function() {

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -5,7 +5,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var jsYaml = require('js-yaml');
+var yamlJs = require('yamljs');
 var Validator = require(
   path.resolve(path.dirname(__dirname), 'index.js'));
 var aboutYmlPath =
@@ -60,9 +60,9 @@ describe('validate', function() {
       var aboutYmlDataBogus,
           results;
 
-      aboutYmlDataBogus = jsYaml.safeLoad(aboutYmlData);
+      aboutYmlDataBogus = yamlJs.parse(aboutYmlData);
       aboutYmlDataBogus.contact = 'bogus';
-      results = validator.validate(jsYaml.safeDump(aboutYmlDataBogus));
+      results = validator.validate(yamlJs.dump(aboutYmlDataBogus));
 
       expect(results).to.eql([{
           'property': 'contact',
@@ -95,7 +95,7 @@ describe('validateFile', function() {
     function(done) {
       validator.validateFile(__filename, check(done, function(err) {
         expect(err).to.not.be.empty;
-        expect(err[0]).to.have.string('YAMLException');
+        expect(err[0]).to.have.string('ParseException');
       }));
   });
 


### PR DESCRIPTION
Turns out, per #3, that js-yaml isn't browserify-friendly. It appears that yamljs is. However, this commit currently causes a test failure:

```
  6 passing (33ms)
  1 failing

  1) validate should return an array of errors if the YAML fails to parse:
     AssertionError: expected undefined not to be empty
      at Context.<anonymous> (test/validator-test.js:48:32)
```

The following payload should fail because strings that contain `:` should be wrapped in quotes:

``` js
      var yamlContents = 'lyric: watch out boy: she\'ll chew you up!',
```

But validation passes because yamljs is a little too smart, and will figure out how to wrap such malformed strings:

``` js
{ lyric: 'watch out boy: she\'ll chew you up!' }
```

**Question: Accept this robust behavior, and find another parse error to use in the test, or try finding another library that is as strict as js-yaml?**

**Question the second:** @jeremiak can you post, either here or in #3, the commands/snippets you used to check the browserification?

cc: @ccostino 
