### PR TITLE
Closes #5:  Match schema changes with 18F/about_yml#46

### DIFF
--- a/lib/schema.json
+++ b/lib/schema.json
@@ -99,7 +99,7 @@
                 ".*": {"$ref": "#/definitions/license"}
             }
         },
-        "blog_tag": {
+        "blogTag": {
             "type": "array",
             "description": "Tag to use when blogging about this project",
             "items": {


### PR DESCRIPTION
This changeset accounts for additional changes to the `blogTag` renaming in the about_yml gem schema.
